### PR TITLE
ユーザーのアクセス範囲の制限

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,7 @@
 class PrototypesController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :authenticate_user!, only: [:new, :destroy]
+  before_action :move_to_index, only: :edit
+
   def index
     @prototypes = Prototype.all 
   end
@@ -45,5 +47,11 @@ class PrototypesController < ApplicationController
   private
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    unless user_signed_in?
+      redirect_to action: :index
+    end
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,5 @@
 class PrototypesController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   def index
     @prototypes = Prototype.all 
   end


### PR DESCRIPTION
# What
ユーザーのアクセス範囲制限機能の実装

# Why
ログインの有無によって遷移できるページを限定するため。